### PR TITLE
Added Offensive Tor Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@
 - [ToRat](https://github.com/lu4p/ToRat) - Cross-platform remote administration tool written in Go using Tor as a transport mechanism.
 - [dos-over-tor](https://github.com/skizap/dos-over-tor) - Proof of concept denial of service over Tor stress test tool.
 - [oregano](https://github.com/nametoolong/oregano) - Python module that runs as a machine-in-the-middle (MITM) accepting Tor client requests.
+- [Offensive Tor Toolkit](https://github.com/atorrescogollo/offensive-tor-toolkit) - Series of tools written in Go that simplify the use of Tor for typical exploitation and post-exploitation tasks.
 
 # Onion service tools
 


### PR DESCRIPTION
Repo URL: https://github.com/atorrescogollo/offensive-tor-toolkit
Docs: https://atorrescogollo.github.io/geekdoc/projects/offensive-tor-toolkit/
PoC: https://atorrescogollo.github.io/geekdoc/posts/offensive-tor-toolkit/