### PR TITLE
Update links to presentation videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@
 - [How Tor Users Got Caught - Defcon 22](https://www.youtube.com/watch?v=eQ2OZKitRwc) - 4 examples of people who have used Tor for illegal activities and how they were caught. Multiple de-anonymization attacks are shown at the end of the video.
 - [How governments have tried to block Tor - 2011](https://www.youtube.com/watch?v=DX46Qv_b7F4) - Iran blocked Tor handshakes using Deep Packet Inspection (DPI) in January 2011 and September 2011, an oldy but goody.
 - [State Of The Onion - 2014](https://www.youtube.com/watch?v=8w6gbD7LIPs) - Covers technical, social, economic, political and cultural issues pertaining to anonymity, the Tor Project and the ecosystem surrounding our communities.
-- [The Tor Network - 2013](https://www.youtube.com/watch?v=CJNxbpbHA-I) - Roger Dingledine and Jacob Appelbaum discuss contemporary Tor Network issues related to censorship, security, privacy and anonymity online.
+- [The Tor Network - 2013](https://www.youtube.com/watch?v=-VUyuFH9CbI) - Roger Dingledine and Jacob Appelbaum discuss contemporary Tor Network issues related to censorship, security, privacy and anonymity online.
 - [Tor: Hidden Services and Deanonymisation - 2014](https://www.youtube.com/watch?v=oZdeRmlj8Gw) - This talk presents the results from what we believe to be one of the largest studies into Tor Hidden Services (The Darknet) to date.
 
 # Development and research tools

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@
 
 - [How Tor Users Got Caught - Defcon 22](https://www.youtube.com/watch?v=eQ2OZKitRwc) - 4 examples of people who have used Tor for illegal activities and how they were caught. Multiple de-anonymization attacks are shown at the end of the video.
 - [How governments have tried to block Tor - 2011](https://www.youtube.com/watch?v=DX46Qv_b7F4) - Iran blocked Tor handshakes using Deep Packet Inspection (DPI) in January 2011 and September 2011, an oldy but goody.
-- [State Of The Onion - 2014](https://www.youtube.com/watch?v=fOwYgAS4TXE) - Covers technical, social, economic, political and cultural issues pertaining to anonymity, the Tor Project and the ecosystem surrounding our communities.
+- [State Of The Onion - 2014](https://www.youtube.com/watch?v=8w6gbD7LIPs) - Covers technical, social, economic, political and cultural issues pertaining to anonymity, the Tor Project and the ecosystem surrounding our communities.
 - [The Tor Network - 2013](https://www.youtube.com/watch?v=CJNxbpbHA-I) - Roger Dingledine and Jacob Appelbaum discuss contemporary Tor Network issues related to censorship, security, privacy and anonymity online.
 - [Tor: Hidden Services and Deanonymisation - 2014](https://www.youtube.com/watch?v=oZdeRmlj8Gw) - This talk presents the results from what we believe to be one of the largest studies into Tor Hidden Services (The Darknet) to date.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 
 # Conference presentations and talks
 
-- [How Tor Users Got Caught - Defcon 22](https://www.youtube.com/watch?v=7G1LjQSYM5Q) - 4 examples of people who have used Tor for illegal activities and how they were caught. Multiple de-anonymization attacks are shown at the end of the video.
+- [How Tor Users Got Caught - Defcon 22](https://www.youtube.com/watch?v=eQ2OZKitRwc) - 4 examples of people who have used Tor for illegal activities and how they were caught. Multiple de-anonymization attacks are shown at the end of the video.
 - [How governments have tried to block Tor - 2011](https://www.youtube.com/watch?v=GwMr8Xl7JMQ) - Iran blocked Tor handshakes using Deep Packet Inspection (DPI) in January 2011 and September 2011, an oldy but goody.
 - [State Of The Onion - 2014](https://www.youtube.com/watch?v=fOwYgAS4TXE) - Covers technical, social, economic, political and cultural issues pertaining to anonymity, the Tor Project and the ecosystem surrounding our communities.
 - [The Tor Network - 2013](https://www.youtube.com/watch?v=CJNxbpbHA-I) - Roger Dingledine and Jacob Appelbaum discuss contemporary Tor Network issues related to censorship, security, privacy and anonymity online.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 # Conference presentations and talks
 
 - [How Tor Users Got Caught - Defcon 22](https://www.youtube.com/watch?v=eQ2OZKitRwc) - 4 examples of people who have used Tor for illegal activities and how they were caught. Multiple de-anonymization attacks are shown at the end of the video.
-- [How governments have tried to block Tor - 2011](https://www.youtube.com/watch?v=GwMr8Xl7JMQ) - Iran blocked Tor handshakes using Deep Packet Inspection (DPI) in January 2011 and September 2011, an oldy but goody.
+- [How governments have tried to block Tor - 2011](https://www.youtube.com/watch?v=DX46Qv_b7F4) - Iran blocked Tor handshakes using Deep Packet Inspection (DPI) in January 2011 and September 2011, an oldy but goody.
 - [State Of The Onion - 2014](https://www.youtube.com/watch?v=fOwYgAS4TXE) - Covers technical, social, economic, political and cultural issues pertaining to anonymity, the Tor Project and the ecosystem surrounding our communities.
 - [The Tor Network - 2013](https://www.youtube.com/watch?v=CJNxbpbHA-I) - Roger Dingledine and Jacob Appelbaum discuss contemporary Tor Network issues related to censorship, security, privacy and anonymity online.
 - [Tor: Hidden Services and Deanonymisation - 2014](https://www.youtube.com/watch?v=oZdeRmlj8Gw) - This talk presents the results from what we believe to be one of the largest studies into Tor Hidden Services (The Darknet) to date.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@
 - [How governments have tried to block Tor - 2011](https://www.youtube.com/watch?v=DX46Qv_b7F4) - Iran blocked Tor handshakes using Deep Packet Inspection (DPI) in January 2011 and September 2011, an oldy but goody.
 - [State Of The Onion - 2014](https://www.youtube.com/watch?v=8w6gbD7LIPs) - Covers technical, social, economic, political and cultural issues pertaining to anonymity, the Tor Project and the ecosystem surrounding our communities.
 - [The Tor Network - 2013](https://www.youtube.com/watch?v=-VUyuFH9CbI) - Roger Dingledine and Jacob Appelbaum discuss contemporary Tor Network issues related to censorship, security, privacy and anonymity online.
-- [Tor: Hidden Services and Deanonymisation - 2014](https://www.youtube.com/watch?v=oZdeRmlj8Gw) - This talk presents the results from what we believe to be one of the largest studies into Tor Hidden Services (The Darknet) to date.
+- [Tor: Hidden Services and Deanonymisation - 2014](https://www.youtube.com/watch?v=HQXRURfrf8w) - This talk presents the results from what we believe to be one of the largest studies into Tor Hidden Services (The Darknet) to date.
 
 # Development and research tools
 


### PR DESCRIPTION
At the moment, all of the links to presentation videos are broken.  This PR replaces these broken links with currently-functional links to alternative uploads of the same presentations.